### PR TITLE
make debounce configurable. debounce calls to API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,18 @@
 ## 0.2.4
 
 - Added support for flutter web
+- Update rxdart
+- Add overlayBorderRadius parameter
+- Add startText parameter
 
 ## 0.2.3
 
-- update rxdart and google_maps_webservice
+- Update rxdart and google_maps_webservice
 
 ## 0.2.0
 
-- better text theme for text input
-- allow proxyUrl with `proxyBaseUrl` and override http client with `httpClient`
+- Better text theme for text input
+- Allow proxyUrl with `proxyBaseUrl` and override http client with `httpClient`
 
 ## 0.1.4
 
@@ -17,38 +20,40 @@
 
 ## 0.1.3
 
-- update rxdart
+- Update rxdart
 
 ## 0.1.2
 
-- fix dark mode
+- Fix dark mode
 
 ## 0.1.1
 
-- fix icons quality
-- fix input border when custom theme
+- Fix icons quality
+- Fix input border when custom theme
 
 ## 0.1.0
 
- - update sdk and fix warnings
+- Update sdk and fix warnings
 
 ## 0.0.5
-  fix usage of radius
+
+- Fix usage of radius
 
 ## 0.0.4
 
 - Open widgets to create your own UI
-- add onError callback
+- Add onError callback
 
 ## 0.0.3
 
-- add padding for overlay on iOS
+- Add padding for overlay on iOS
 
 ## 0.0.2
 
 - Update google_maps_webservice to ^0.0.3
-- fix placeholder position
-- fix keyboard clipping on overlay
+- Fix placeholder position
+- Fix keyboard clipping on overlay
 
 ## 0.0.1
-Initial version
+
+- Initial version

--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@ Google places autocomplete widgets for flutter.
 
 <div style="text-align: center"><table><tr>
     <td style="text-align: center">
-<img src="https://github.com/lejard-h/flutter_google_places/blob/master/flutter_01.png" height="400">
+<img src="https://raw.githubusercontent.com/fluttercommunity/flutter_google_places/master/flutter_01.png" height="400">
 </td>
 <td style="text-align: center">
-<img src="https://github.com/lejard-h/flutter_google_places/blob/master/flutter_02.png" height="400">
+<img src="https://raw.githubusercontent.com/fluttercommunity/flutter_google_places/master/flutter_02.png" height="400">
 </td>
 </tr>
 </table>

--- a/lib/src/flutter_google_places.dart
+++ b/lib/src/flutter_google_places.dart
@@ -166,7 +166,7 @@ class _PlacesAutocompleteOverlayState extends PlacesAutocompleteState {
     return container;
   }
 
-  Icon get _iconBack => -Theme.of(context).platform == TargetPlatform.iOS
+  Icon get _iconBack => Theme.of(context).platform == TargetPlatform.iOS
       ? Icon(Icons.arrow_back_ios): Icon(Icons.arrow_back);
 
 

--- a/lib/src/flutter_google_places.dart
+++ b/lib/src/flutter_google_places.dart
@@ -11,6 +11,7 @@ import 'package:rxdart/rxdart.dart';
 
 class PlacesAutocompleteWidget extends StatefulWidget {
   final String apiKey;
+  final String startText;
   final String hint;
   final Location location;
   final num offset;
@@ -53,7 +54,8 @@ class PlacesAutocompleteWidget extends StatefulWidget {
       this.onError,
       Key key,
       this.proxyBaseUrl,
-      this.httpClient})
+      this.httpClient,
+      this.startText})
       : super(key: key);
 
   @override
@@ -345,7 +347,7 @@ abstract class PlacesAutocompleteState extends State<PlacesAutocompleteWidget> {
   @override
   void initState() {
     super.initState();
-    _queryTextController = TextEditingController(text: "");
+    _queryTextController = TextEditingController(text: widget.startText);
 
     _places = GoogleMapsPlaces(
         apiKey: widget.apiKey,
@@ -443,7 +445,8 @@ class PlacesAutocomplete {
       Widget logo,
       ValueChanged<PlacesAutocompleteResponse> onError,
       String proxyBaseUrl,
-      Client httpClient}) {
+      Client httpClient,
+      String startText=""}) {
     final builder = (BuildContext ctx) => PlacesAutocompleteWidget(
         apiKey: apiKey,
         mode: mode,
@@ -459,7 +462,8 @@ class PlacesAutocomplete {
         logo: logo,
         onError: onError,
         proxyBaseUrl: proxyBaseUrl,
-        httpClient: httpClient);
+        httpClient: httpClient,
+        startText: startText,);
 
     if (mode == Mode.overlay) {
       return showDialog(context: context, builder: builder);

--- a/lib/src/flutter_google_places.dart
+++ b/lib/src/flutter_google_places.dart
@@ -116,7 +116,7 @@ class _PlacesAutocompleteOverlayState extends PlacesAutocompleteState {
           )
     ]);
 
-    var body;
+    Widget body;
 
     if (_searching) {
       body = Stack(
@@ -168,7 +168,7 @@ class _PlacesAutocompleteOverlayState extends PlacesAutocompleteState {
     return container;
   }
 
-  Icon get _iconBack => -Theme.of(context).platform == TargetPlatform.iOS
+  Icon get _iconBack => Theme.of(context).platform == TargetPlatform.iOS
       ? Icon(Icons.arrow_back_ios): Icon(Icons.arrow_back);
 
 

--- a/lib/src/flutter_google_places.dart
+++ b/lib/src/flutter_google_places.dart
@@ -12,6 +12,7 @@ import 'package:rxdart/rxdart.dart';
 class PlacesAutocompleteWidget extends StatefulWidget {
   final String apiKey;
   final String hint;
+  final BorderRadius overlayBorderRadius;
   final Location location;
   final num offset;
   final num radius;
@@ -41,6 +42,7 @@ class PlacesAutocompleteWidget extends StatefulWidget {
       {@required this.apiKey,
       this.mode = Mode.fullscreen,
       this.hint = "Search",
+      this.overlayBorderRadius,
       this.offset,
       this.location,
       this.radius,
@@ -85,11 +87,19 @@ class _PlacesAutocompleteOverlayState extends PlacesAutocompleteState {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
 
+    final headerTopLeftBorderRadius = widget.overlayBorderRadius != null ? 
+      widget.overlayBorderRadius.topLeft : Radius.circular(2);
+
+    final headerTopRightBorderRadius = widget.overlayBorderRadius != null ? 
+      widget.overlayBorderRadius.topRight : Radius.circular(2);
+
     final header = Column(children: <Widget>[
       Material(
           color: theme.dialogBackgroundColor,
           borderRadius: BorderRadius.only(
-              topLeft: Radius.circular(2.0), topRight: Radius.circular(2.0)),
+            topLeft: headerTopLeftBorderRadius,
+            topRight: headerTopRightBorderRadius
+          ),
           child: Row(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: <Widget>[
@@ -116,6 +126,12 @@ class _PlacesAutocompleteOverlayState extends PlacesAutocompleteState {
 
     var body;
 
+    final bodyBottomLeftBorderRadius = widget.overlayBorderRadius != null ? 
+      widget.overlayBorderRadius.bottomLeft : Radius.circular(2);
+
+    final bodyBottomRightBorderRadius = widget.overlayBorderRadius != null ? 
+      widget.overlayBorderRadius.bottomRight : Radius.circular(2);
+
     if (_searching) {
       body = Stack(
         children: <Widget>[_Loader()],
@@ -128,15 +144,16 @@ class _PlacesAutocompleteOverlayState extends PlacesAutocompleteState {
         color: theme.dialogBackgroundColor,
         child: widget.logo ?? PoweredByGoogleImage(),
         borderRadius: BorderRadius.only(
-            bottomLeft: Radius.circular(2.0),
-            bottomRight: Radius.circular(2.0)),
+          bottomLeft: bodyBottomLeftBorderRadius,
+          bottomRight: bodyBottomRightBorderRadius,
+        ),
       );
     } else {
       body = SingleChildScrollView(
         child: Material(
           borderRadius: BorderRadius.only(
-            bottomLeft: Radius.circular(2.0),
-            bottomRight: Radius.circular(2.0),
+            bottomLeft: bodyBottomLeftBorderRadius,
+            bottomRight: bodyBottomRightBorderRadius,
           ),
           color: theme.dialogBackgroundColor,
           child: ListBody(
@@ -432,6 +449,7 @@ class PlacesAutocomplete {
       @required String apiKey,
       Mode mode = Mode.fullscreen,
       String hint = "Search",
+      BorderRadius overlayBorderRadius,
       num offset,
       Location location,
       num radius,
@@ -447,6 +465,7 @@ class PlacesAutocomplete {
     final builder = (BuildContext ctx) => PlacesAutocompleteWidget(
         apiKey: apiKey,
         mode: mode,
+        overlayBorderRadius: overlayBorderRadius,
         language: language,
         sessionToken: sessionToken,
         components: components,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  rxdart: ^0.22.0
+  rxdart: ^0.23.1
   google_maps_webservice: ^0.0.15
   http: ">=0.11.0 <1.0.0"
 


### PR DESCRIPTION
Putting a debounce on the `_queryBehavior.stream` wasn't working for me. It was still calling the API as quickly as I was typing. I was getting lots of rate limit errors. This solution seems to do the trick.